### PR TITLE
Add exec-env

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ "$ASDF_INSTALL_VERSION" != "system" ]; then
+  if [ -z "$DENO_DIR" ]; then
+    export DENO_DIR=$ASDF_INSTALL_PATH/.cache/deno
+  fi
+fi


### PR DESCRIPTION
It will set `DENO_DIR` in the asdf directory if the version is not `system`, and the user does not explicitly set `DENO_DIR`.