### PR TITLE
Do not separate deno cache between versions

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -4,8 +4,4 @@ if [ "$ASDF_INSTALL_VERSION" != "system" ]; then
   if [ -z "$DENO_INSTALL_ROOT" ]; then
     export DENO_INSTALL_ROOT=$ASDF_INSTALL_PATH/.deno
   fi
-
-  if [ -z "$DENO_DIR" ]; then
-    export DENO_DIR=$ASDF_INSTALL_PATH/.cache/deno
-  fi
 fi


### PR DESCRIPTION
**Reasoning**

1. Modules in cache do not depend on specific deno version
2. Custom cache folder breaks vscode-deno extension https://github.com/denoland/vscode_deno/issues/231

I thought about removing custom `DENO_INSTALL_ROOT` as well, but seems like it will be a breaking change for existing users.

**Related**
https://github.com/asdf-community/asdf-deno/issues/17#issuecomment-698261897
https://github.com/denoland/vscode_deno/issues/231