### PR TITLE
Add support for aarch64-apple-darwin

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,8 +31,15 @@ install_deno() {
 
     case "$(uname -m)" in
       x86_64) architecture="x86_64" ;;
+      arm64) architecture="aarch64" ;;
       *) fail "Unsupported architecture" ;;
     esac
+    
+    if [ $architecture = "aarch64" ]; then
+      if [[ $version < "1.6.0" ]] || [ $platform != "apple-darwin" ]; then
+        fail "Unsupported architecture"
+      fi
+    fi
 
     archive_format="zip"
     archive_file="deno-${architecture}-${platform}.${archive_format}"

--- a/bin/install
+++ b/bin/install
@@ -35,12 +35,6 @@ install_deno() {
       *) fail "Unsupported architecture" ;;
     esac
     
-    if [ $architecture = "aarch64" ]; then
-      if [[ $version < "1.6.0" ]] || [ $platform != "apple-darwin" ]; then
-        fail "Unsupported architecture"
-      fi
-    fi
-
     archive_format="zip"
     archive_file="deno-${architecture}-${platform}.${archive_format}"
     uncompress_command="unzip -d ${install_path}/bin"

--- a/bin/install
+++ b/bin/install
@@ -34,7 +34,7 @@ install_deno() {
       arm64) architecture="aarch64" ;;
       *) fail "Unsupported architecture" ;;
     esac
-    
+
     archive_format="zip"
     archive_file="deno-${architecture}-${platform}.${archive_format}"
     uncompress_command="unzip -d ${install_path}/bin"


### PR DESCRIPTION
Adds support for arm64 when installing a version greater than or equal to 1.6 on macOS running on Apple Silicon. Currently any attempt to install on an Apple Silicon system will fail with "Unsupported architecture" error.