### PR TITLE
Update exec-env

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+DENO_INSTALL_ROOT=${DENO_INSTALL_ROOT:-}
+
 if [ "$ASDF_INSTALL_VERSION" != "system" ]; then
   if [ -z "$DENO_INSTALL_ROOT" ]; then
     export DENO_INSTALL_ROOT=$ASDF_INSTALL_PATH/.deno


### PR DESCRIPTION
When using with asdf-direnv with direnv configured as strict_env=true, it fails with `./exec-env:4: DENO_INSTALL_ROOT: unbound variable`

Original issue: https://github.com/asdf-community/asdf-direnv/issues/115