### PR TITLE
Add support for running in a windows bash prompt (i.e Git for Windows)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -37,6 +37,7 @@ install_deno() {
     case "$OSTYPE" in
       darwin*) platform="apple-darwin" ;;
       linux*) platform="unknown-linux-gnu" ;;
+      msys*) platform="pc-windows-msvc" ;;
       *) fail "Unsupported platform" ;;
     esac
 


### PR DESCRIPTION
As the title says this allows asdf deno plugin to work in Git for Windows bash prompt with out any other dependencies needed. Should also work with any other msys built environment (potentially GOW as well though that is an older version of bash etc)

https://gitforwindows.org/

Tested using `scoop install git` then run Bash