### PR TITLE
Update list-all to fetch stable and RC versions from deno website

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -3,11 +3,7 @@
 set -eo pipefail
 
 cmd="curl --silent --location"
-releases_path="https://api.github.com/repos/denoland/deno/releases?per_page=100"
-
-if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd --header 'Authorization: token $GITHUB_API_TOKEN'"
-fi
+versions_url="https://deno.com/versions.json"
 
 sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
@@ -15,9 +11,10 @@ sort_versions() {
 }
 
 versions=$(
-  eval "$cmd $releases_path" |
-    grep -o '"name": "v.*' |
-    sed 's/"name": "v\(.*\)",/\1/' |
+  eval "$cmd $versions_url" |
+    sed -n 's/.*"cli":\[\(.*\)\].*/\1/p' |    # Extract everything inside "cli": [ ... ]
+    grep -o '"v[0-9.]\+\(-rc\.[0-9]\+\)\?"' | # Extract all versions
+    sed 's/"v\(.*\)"/\1/' |                   # Remove the "v" prefix and quotes
     sort_versions |
     xargs
 )


### PR DESCRIPTION
This PR should work along with #44 and help resolve #45 

---

I've was looking into ways to include release candidate versions, and I found that the [denoland/setup-deno](https://github.com/denoland/setup-deno) GitHub Action might offer a useful approach.

They fetch version information from https://deno.com/versions.json, which provides a list of all available Deno versions, including stable, and release candidates. Here’s an example response:

```json
{
  "cli": [
    "v2.0.0-rc.10",
    "v2.0.0-rc.9",
    ...
    "v1.46.3",
    "v1.46.2",
    ...
  ],
  "std": [
    ...
  ]
}
```

This might be a helpful alternative to the GitHub releases API for managing version resolution, especially when dealing with release candidates. It could simplify access to all available versions, including release candidates, in one place.